### PR TITLE
New command for generation of modules description

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -49,7 +49,7 @@ jobs:
     - name: 'Generate cepgen documentation'
       working-directory: /Documentation/build
       run: |
-        ${{ env.CEPGEN_PATH }}/build/bin/cepgenDocGenerator -o /Documentation/.raw_modules.html -t 0 -g 0 -e
+        ${{ env.CEPGEN_PATH }}/build/bin/cepgenDescribeModules -D "ctml<{useBS:on,pageTitle:,showGit:off,bare:on}" -o /Documentation/.raw_modules.html
         cmake --build /Documentation/build
 
     - name: 'Upload Sphinx/Doxygen website'


### PR DESCRIPTION
As the name indicates, this PR updates the generation command for the HTML modules description on the CepGen website.
It goes along with https://github.com/cepgen/cepgen/pull/66.